### PR TITLE
Supports to query token IDs in pagination view for CRC721 and CRC1155

### DIFF
--- a/contracts/token/CRC1155/extensions/CRC1155Enumerable.sol
+++ b/contracts/token/CRC1155/extensions/CRC1155Enumerable.sol
@@ -6,9 +6,11 @@ import "./ICRC1155Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 abstract contract CRC1155Enumerable is ERC1155, ICRC1155Enumerable {
     using EnumerableSet for EnumerableSet.UintSet;
+    using Math for uint256;
 
     // All token ids for enumeration.
     EnumerableSet.UintSet private _allTokens;
@@ -31,6 +33,23 @@ abstract contract CRC1155Enumerable is ERC1155, ICRC1155Enumerable {
      */
     function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
         return _allTokens.at(index);
+    }
+
+    /**
+     * @dev Returns token IDs in pagination view.
+     */
+    function tokens(uint256 offset, uint256 limit) public view virtual returns (uint256 total, uint256[] memory tokenIds) {
+        total = totalSupply();
+        if (total == 0 || offset >= total) {
+            return (total, new uint256[](0));
+        }
+
+        uint256 endExclusive = total.min(offset + limit);
+        tokenIds = new uint256[](endExclusive - offset);
+
+        for (uint256 i = offset; i < endExclusive; i++) {
+            tokenIds[i - offset] = tokenByIndex(i);
+        }
     }
 
     /**
@@ -59,6 +78,23 @@ abstract contract CRC1155Enumerable is ERC1155, ICRC1155Enumerable {
      */
     function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
         return _ownedTokens[owner].at(index);
+    }
+
+    /**
+     * @dev Returns token IDs of specified `owner` in pagination view.
+     */
+    function tokensOf(address owner, uint256 offset, uint256 limit) public view virtual returns (uint256 total, uint256[] memory tokenIds) {
+        total = tokenCountOf(owner);
+        if (total == 0 || offset >= total) {
+            return (total, new uint256[](0));
+        }
+
+        uint256 endExclusive = total.min(offset + limit);
+        tokenIds = new uint256[](endExclusive - offset);
+
+        for (uint256 i = offset; i < endExclusive; i++) {
+            tokenIds[i - offset] = tokenOfOwnerByIndex(owner, i);
+        }
     }
 
     /**

--- a/contracts/token/CRC1155/presets/CRC1155PresetAutoId.sol
+++ b/contracts/token/CRC1155/presets/CRC1155PresetAutoId.sol
@@ -38,28 +38,6 @@ contract CRC1155PresetAutoId is ERC1155PresetMinterPauser, CRC1155Enumerable {
     }
 
     /**
-     * @dev Creates a new token for `to` with auto-generated token ID.
-     * 
-     * Requirements:
-     *
-     * - the caller must have the `MINTER_ROLE`.
-     */
-    function mint(address to) public virtual {
-        mint(to, 1);
-    }
-
-    /**
-     * @dev Creates `amount` new tokens for `to` with auto-generated token ID.
-     * 
-     * Requirements:
-     *
-     * - the caller must have the `MINTER_ROLE`.
-     */
-    function mint(address to, uint256 amount) public virtual {
-        mint(to, amount, "");
-    }
-
-    /**
      * @dev Creates `amount` new tokens for `to` with auto-generated token ID and additional data.
      * 
      * Requirements:
@@ -69,38 +47,6 @@ contract CRC1155PresetAutoId is ERC1155PresetMinterPauser, CRC1155Enumerable {
     function mint(address to, uint256 amount, bytes memory data) public virtual {
         mint(to, _tokenIdTracker.current(), amount, data);
         _tokenIdTracker.increment();
-    }
-
-    /**
-     * @dev Creates tokens with auto-generated token IDs in batch.
-     * @param to address to mint tokens.
-     * @param count number of token IDs to mint, each token id has amount of 1.
-     * 
-     * Requirements:
-     *
-     * - the caller must have the `MINTER_ROLE`.
-     */
-    function mintBatch(address to, uint256 count) public virtual {
-        uint256[] memory amounts = new uint256[](count);
-
-        for (uint i = 0; i < count; i++) {
-            amounts[i] = 1;
-        }
-
-        mintBatch(to, amounts);
-    }
-
-    /**
-     * @dev Creates tokens with auto-generated token IDs in batch.
-     * @param to address to mint tokens.
-     * @param amounts amount for each token ID to mint.
-     * 
-     * Requirements:
-     *
-     * - the caller must have the `MINTER_ROLE`.
-     */
-    function mintBatch(address to, uint256[] memory amounts) public virtual {
-        mintBatch(to, amounts, "");
     }
 
     /**

--- a/contracts/token/CRC721/extensions/CRC721Enumerable.sol
+++ b/contracts/token/CRC721/extensions/CRC721Enumerable.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
+abstract contract CRC721Enumerable is ERC721Enumerable {
+    using Math for uint256;
+
+    /**
+     * @dev Returns token IDs in pagination view.
+     */
+    function tokens(uint256 offset, uint256 limit) public view virtual returns (uint256 total, uint256[] memory tokenIds) {
+        total = totalSupply();
+        if (total == 0 || offset >= total) {
+            return (total, new uint256[](0));
+        }
+
+        uint256 endExclusive = total.min(offset + limit);
+        tokenIds = new uint256[](endExclusive - offset);
+
+        for (uint256 i = offset; i < endExclusive; i++) {
+            tokenIds[i - offset] = tokenByIndex(i);
+        }
+    }
+
+    /**
+     * @dev Returns token IDs of specified `owner` in pagination view.
+     */
+    function tokensOf(address owner, uint256 offset, uint256 limit) public view virtual returns (uint256 total, uint256[] memory tokenIds) {
+        total = balanceOf(owner);
+        if (total == 0 || offset >= total) {
+            return (total, new uint256[](0));
+        }
+
+        uint256 endExclusive = total.min(offset + limit);
+        tokenIds = new uint256[](endExclusive - offset);
+
+        for (uint256 i = offset; i < endExclusive; i++) {
+            tokenIds[i - offset] = tokenOfOwnerByIndex(owner, i);
+        }
+    }
+
+}


### PR DESCRIPTION
- Add pagination APIs for CRC1155Enumerable by default.
- Add CRC721Enumerable for pagination APIs.
- Remove some `mint/mintBatch` APIs for code size reduction so as not to reach the 24K limit on Ethereum.

If more APIs added in future and code size reached the 24K limitation, then pagination APIs could be moved to a separate auxiliary contract for batch query.